### PR TITLE
adds native segwit script types support

### DIFF
--- a/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/SigHashTypes.java
+++ b/core/src/main/java/com/neemre/btcdcli4j/core/domain/enums/SigHashTypes.java
@@ -22,6 +22,8 @@ public enum SigHashTypes {
 	ALL_ACP("ALL|ANYONECANPAY"),
 	NONE_ACP("NONE|ANYONECANPAY"),
 	SINGLE_ACP("SINGLE|ANYONECANPAY");
+	WITNESS_V0_KEYHASH("witness_v0_keyhash");
+	WITNESS_V0_SCRIPTHASH("witness_v0_scripthash");
 	
 	private final String name;
 


### PR DESCRIPTION
- **_BtcdClient.decodeRawTransaction_** raises an IllegalArgumentException on parsing native segwit script types: _witness_v0_keyhash, witness_v0_scripthash_

e.g.

`java.lang.IllegalArgumentException: Error #1001010: Expected the argument to be a valid 'bitcoind' script type, but was invalid/unsupported instead.
2017-08-29 03:59:06.839431500   at com.neemre.btcdcli4j.core.domain.enums.ScriptTypes.forName(ScriptTypes.java:43)` 

This patch adds the missing enums to fix.